### PR TITLE
Added metro strict compatibility check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ There is a sample Android app under [`:sample`](sample) that demonstrates how we
 
 Metro Station uses a composite versioning scheme that appends Metro's version as a suffix. For example, `0.1.0-1.1.1` means it is based on Metro `1.1.1`. We have two compatibility guards:
 1. There is a GitHub workflow that builds the repository daily against Metro's latest snapshot, allowing us to catch breaking changes early.
-2. In the main BandLab Android repository, we have a version check ensuring that Metro's version matches Metro Station's version.
+2. By default, the gradle plugin will check the Metro version during the configuration. You can disable it by using the gradle property `com.bandlab.metro.station.metroStrictCompatibility=false`.
 
 ## Caveats
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -46,6 +46,7 @@ buildConfig {
     buildConfigField("String", "KOTLIN_PLUGIN_GROUP", "\"${pluginProject.group}\"")
     buildConfigField("String", "KOTLIN_PLUGIN_NAME", "\"${pluginProject.name}\"")
     buildConfigField("String", "KOTLIN_PLUGIN_VERSION", "\"${pluginProject.version}\"")
+    buildConfigField("String", "SUPPORTED_METRO_VERSION", "\"${pluginProject.libs.versions.metro.get()}\"")
 
     val annotationsProject = project(":plugin-annotations")
     buildConfigField(

--- a/gradle-plugin/src/com/bandlab/metro/station/MetroStationGradlePlugin.kt
+++ b/gradle-plugin/src/com/bandlab/metro/station/MetroStationGradlePlugin.kt
@@ -1,6 +1,7 @@
 package com.bandlab.metro.station
 
 import com.bandlab.metro.station.BuildConfig.ANNOTATIONS_LIBRARY_COORDINATES
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
@@ -11,8 +12,33 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 // Used via reflection.
 @Suppress("unused")
 public class MetroStationGradlePlugin : KotlinCompilerPluginSupportPlugin {
-    override fun apply(target: Project) {
-        target.extensions.create("metroStation", MetroStationExtension::class.java)
+    override fun apply(project: Project) {
+        project.extensions.create("metroStation", MetroStationExtension::class.java)
+
+        val isMetroStrictCompatibility = project.providers
+            .gradleProperty("com.bandlab.metro.station.metroStrictCompatibility")
+            .map { it.toBoolean() }
+            .getOrElse(true)
+        if (isMetroStrictCompatibility) {
+            var metroVersion: String? = null
+            project.plugins.withId("dev.zacsweers.metro") {
+                val clazz = Class.forName("dev.zacsweers.metro.gradle.BuildConfigKt")
+                val property = clazz.fields.find { it.name == "VERSION" }
+
+                metroVersion = property?.let {
+                    it.isAccessible = true
+                    it.get(null)?.toString()
+                }
+            }
+            project.afterEvaluate {
+                if (BuildConfig.SUPPORTED_METRO_VERSION != metroVersion) {
+                    throw GradleException(
+                        "Metro Station version (${BuildConfig.KOTLIN_PLUGIN_VERSION}) is incompatible with Metro version ($metroVersion).\n" +
+                            "It might work but it's safer to keep them in sync. Please make a new release of metro station."
+                    )
+                }
+            }
+        }
     }
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true


### PR DESCRIPTION
Added metro strict compatibility check.  It can be disabled by using the gradle property `com.bandlab.metro.station.metroStrictCompatibility=false`.