### PR TITLE
Run snapshot validation on metro-snapshot branch if it exists

### DIFF
--- a/.github/workflows/validate-metro-snapshot.yml
+++ b/.github/workflows/validate-metro-snapshot.yml
@@ -12,6 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Checkout metro-snapshot branch if it exists
+        run: |
+          if git ls-remote --heads origin metro-snapshot | grep -q metro-snapshot; then
+            git fetch origin metro-snapshot
+            git checkout metro-snapshot
+          fi
+
       - name: Fetch latest Metro snapshot version
         id: snapshot
         run: |


### PR DESCRIPTION
The idea is to have a `metro-snapshot` branch separated from `main`, and we can gradually adopt required changes there, and finally merge it back to main when metro has new releases.